### PR TITLE
Fix Mosquitto authorisation issue

### DIFF
--- a/mosquitto/config/mosquitto.conf
+++ b/mosquitto/config/mosquitto.conf
@@ -4,3 +4,4 @@ protocol websockets
 persistence true
 persistence_location /mosquitto/data/
 log_dest file /mosquitto/log/mosquitto.log
+allow_anonymous true


### PR DESCRIPTION
Recently had to scrub my `/var/lib/docker` directory on my pi and I had a version of this repo running on it ( https://github.com/Notaphish/nota_smarthome_dashboard/tree/main/ruuvitag ).

For some reason after the reinstall none of my clients could connect to Mosquitto ( hive client or node-red ). Turns it out it was an auth issue and adding this flag sorted all my problems out ( rather than creating username and password file for Mosquitto ). https://mosquitto.org/man/mosquitto-conf-5.html

Not sure if I had this problem before, don't remember it occurring, regardless figured I'd raise this in-case anyone else has this problem.